### PR TITLE
optimize `is_valid_isin()` to only validate unique ISINs

### DIFF
--- a/R/is_valid_isin.R
+++ b/R/is_valid_isin.R
@@ -16,6 +16,10 @@ is_valid_isin <- function(isins) {
     isins <- isins[[1L]]
   }
 
+  isins[is.na(isins)] <- "X" # set NAs to something sure to return FALSE
+  isins_factored <- as.factor(isins)
+  isins_lvls <- levels(isins_factored)
+
   is_luhn <- function(x) {
     digits <- suppressWarnings(as.numeric(rev(unlist(strsplit(x, "")))))
     odd <- seq_along(digits) %% 2 == 1
@@ -25,13 +29,13 @@ is_valid_isin <- function(isins) {
     sum(s1, s2) %% 10 == 0
   }
 
-  isins <- toupper(isins)
-  isins <- gsub(pattern = "[[:blank:]]", replacement = "", isins)
-  valid_struct <- grepl("^[[:upper:]]{2}[[:alnum:]]{9}[[:digit:]]$", isins)
+  isins_lvls <- toupper(isins_lvls)
+  isins_lvls <- gsub(pattern = "[[:blank:]]", replacement = "", isins_lvls)
+  valid_struct <- grepl("^[[:upper:]]{2}[[:alnum:]]{9}[[:digit:]]$", isins_lvls)
 
   valid_luhn <-
     vapply(
-      X = isins,
+      X = isins_lvls,
       FUN = function(x) {
         x <-
           stringi::stri_replace_all_fixed(
@@ -54,5 +58,5 @@ is_valid_isin <- function(isins) {
       USE.NAMES = FALSE
     )
 
-  valid_struct & valid_luhn
+  valid_struct[as.numeric(isins_factored)] & valid_luhn[as.numeric(isins_factored)]
 }


### PR DESCRIPTION
closes #8 

``` r
isins <- c(
  "CH0347556935",
  "CH0278875940",
  "CH0282018990",
  "CH0269836703",
  "CH0433761282",
  "CH0407809794",
  "CH0537261874",
  "CH0398677697",
  "CH0299477353",
  "CH0302790115",
  "CH0272024669",
  "CH0538763506",
  "CH0370634633",
  "CH0441186514",
  "CH0537261924",
  "CH0386949348",
  "CH0528881227"
)

library(microbenchmark)
library(ggplot2)

mbm <- microbenchmark(
  new = is_valid_isin(rep(isins, 1e3)),
  old = pacta.portfolio.import::is_valid_isin(rep(isins, 1e3))
)
#> Warning in microbenchmark(new = is_valid_isin(rep(isins, 1000)), old =
#> pacta.portfolio.import::is_valid_isin(rep(isins, : less accurate nanosecond
#> times to avoid potential integer overflows

mbm
#> Unit: microseconds
#>  expr        min         lq       mean     median         uq       max neval
#>   new    969.691   1063.909   1236.259   1090.272   1130.083  13712.53   100
#>   old 297929.329 301034.464 304805.983 302466.204 303629.846 337030.82   100

autoplot(mbm)
#> Coordinate system already present. Adding new coordinate system, which will
#> replace the existing one.
```

![](https://i.imgur.com/SLYYVJi.png)<!-- -->