### PR TITLE
remove encoding check on merge queue

### DIFF
--- a/.github/workflows/pr-check-file-encodings.yml
+++ b/.github/workflows/pr-check-file-encodings.yml
@@ -1,5 +1,5 @@
 name: check file encodings in PR
-on: [pull_request, merge_group]
+on: pull_request
 jobs:
   file-encoding:
     name: file encoding check


### PR DESCRIPTION
encoding check doesn't work properly with the branches that are auto created during merge queue