### PR TITLE
ensure `grepl()` has UTF-8 input to avoid error

### DIFF
--- a/R/has_newline_at_end.R
+++ b/R/has_newline_at_end.R
@@ -23,7 +23,7 @@ has_newline_at_end <- function(filepaths) {
         }
       }
 
-      grepl("[\n\r]$", prev_chars)
+      grepl("[\n\r]$", iconv(prev_chars, to = "UTF-8", sub = ""))
     },
     FUN.VALUE = logical(1),
     USE.NAMES = FALSE


### PR DESCRIPTION
When running tests locally, I got an error which was ultimately caused by multi-byte strings encoded in ISO-8859-1. It would fail when checking if there is a newline at the end of the file, because under some not-entirely-known combination of things (OS version, R version, etc.) `grepl()` was throwing an error when parsing the string with multi-byte characters. This fix ensures that the string loaded in memory is converted to a proper UTF-8 string before letting `grepl()` parse it.