### PR TITLE
remove R CMD check Action timeout

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,7 +12,6 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
-    timeout-minutes: 18
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
     strategy:


### PR DESCRIPTION
I hate doing this, because even though this repo is public and therefore we don't pay for any Action minutes, I don't like the idea of letting these Actions eat up hours of compute time every once in a while when something hangs, but.... the R devel branch frequently takes a ton of time to build all the packages from source, which is frequently causing failures unrelated to anything in the PRs.