### PR TITLE
Externalize file read

### DIFF
--- a/R/read_portfolio_csv.R
+++ b/R/read_portfolio_csv.R
@@ -62,6 +62,16 @@ read_portfolio_csv <- function(filepaths, combine = TRUE) {
 
 read_single_portfolio_csv <- function(filepath) {
 
+  if (length(filepath) != 1L) {
+    stop("`filepath` must be a single string")
+  }
+  if (typeof(filepath) != "character") {
+    stop("`filepath` must be a string")
+  }
+  if (!file.exists(filepath)) {
+    stop(paste("file does not exist:", filepath))
+  }
+
   if (!is_text_file(filepath)) {
     return(list(NA))
   }


### PR DESCRIPTION
This PR externalizes most of the contents of the `vapply` loop in `read_portfolio_csv()` to a separate function which can read a single portfolio file. Externalizing this function allows us to alter it in the future to be more permissive if desired, and use it directly in `workflow.portfolio.parsing`

The primary logical/behavior change here is to add some checks at the beginning of the function to check that we're dealing with a single (existing) filepath.