### PR TITLE
Fix/correct behavior on trailling cr

### DIFF
--- a/R/has_newline_at_end.R
+++ b/R/has_newline_at_end.R
@@ -23,7 +23,10 @@ has_newline_at_end <- function(filepaths) {
         }
       }
 
-      grepl("[\n\r]$", iconv(prev_chars, to = "UTF-8", sub = ""))
+      # using [\n] instead of [\n\r] because modern systems use either \n or
+      # \r\n as newline, both of which match \n as last character.
+      # \r as last character should not be recognized as trailing newline.
+      grepl("[\n]$", iconv(prev_chars, to = "UTF-8", sub = ""))
     },
     FUN.VALUE = logical(1),
     USE.NAMES = FALSE

--- a/tests/testthat/test-has_newline_at_end.R
+++ b/tests/testthat/test-has_newline_at_end.R
@@ -13,10 +13,10 @@ test_that("has_newline_at_end identifies trailing newline", {
 })
 
 test_that("has_newline_at_end identifies trailing return", {
-  return <- withr::local_tempfile()
-  writeChar("A,B\r1,2\r", return, eos = NULL)
-  expect_true(tail(readBin(return, what = "raw", n = 10), n = 1) == charToRaw("\r"))
-  expect_false(has_newline_at_end(return))
+  trailing_return <- withr::local_tempfile()
+  writeChar("A,B\r1,2\r", trailing_return, eos = NULL)
+  expect_true(tail(readBin(trailing_return, what = "raw", n = 10), n = 1) == charToRaw("\r"))
+  expect_false(has_newline_at_end(trailing_return))
 })
 
 test_that("has_newline_at_end identifies trailing return and newline", {

--- a/tests/testthat/test-has_newline_at_end.R
+++ b/tests/testthat/test-has_newline_at_end.R
@@ -16,7 +16,7 @@ test_that("has_newline_at_end identifies trailing return", {
   return <- withr::local_tempfile()
   writeChar("A,B\r1,2\r", return, eos = NULL)
   expect_true(tail(readBin(return, what = "raw", n = 10), n = 1) == charToRaw("\r"))
-  expect_true(has_newline_at_end(return))
+  expect_false(has_newline_at_end(return))
 })
 
 test_that("has_newline_at_end identifies trailing return and newline", {


### PR DESCRIPTION
I made a mistake in my review on #60, since `\r` should not be recognized as a trailing newline (no modern system writes files with that as the trailing character). Both the unix LF and windows CRLF line endings end with `\n`.