### PR TITLE
Fix/73 fix behavior for headers only files

### DIFF
--- a/tests/testthat/test-read_portfolio_csv.R
+++ b/tests/testthat/test-read_portfolio_csv.R
@@ -186,3 +186,14 @@ test_that("reads a portfolio CSV with numeric names as characters", {
   expect_type(result$investor_name, "character")
   expect_type(result$portfolio_name, "character")
 })
+
+test_that("reads a portfolio CSV with numeric names as characters", {
+  csv_file <- withr::local_tempfile(fileext = ".csv")
+
+  portfolio_alt <- portfolio_min[0L, ]
+
+  readr::write_csv(portfolio_alt, file = csv_file)
+
+  result <- read_portfolio_csv(csv_file)
+  expect_identical(result, NA)
+})


### PR DESCRIPTION
Adds a check in `read_portfolio_csv()` for the file to be multiple rows, or if a single row file that it be a non-header row. Logic is largely cribbed from `determine_headers()`, but given the amount of variable reuse there, I think it makes sense to reuse the logic rather than factor out a separate function at this point.

Fixes #73 