### PR TITLE
add `merge_group` trigger to `pr-check-file-encodings.yml`

### DIFF
--- a/.github/workflows/pr-check-file-encodings.yml
+++ b/.github/workflows/pr-check-file-encodings.yml
@@ -15,11 +15,11 @@ jobs:
           fetch-depth: 0
       - name: list all changed files
         run: |
-          files=$(git diff --name-only origin/$GITHUB_BASE_REF...${{ github.sha }})
+          files=$(git diff --name-only origin/main...${{ github.sha }})
           IFS=$'\n'; files=($files); unset IFS;  # split the string into an array
           file --mime "${files[@]}"
       - name: list all changed files with the wrong encoding
         run: |
-          files=$(git diff --name-only origin/$GITHUB_BASE_REF...${{ github.sha }})
+          files=$(git diff --name-only origin/main...${{ github.sha }})
           IFS=$'\n'; files=($files); unset IFS;  # split the string into an array
           ! file --mime "${files[@]}" | grep -v "charset=utf-8\|charset=us-ascii\|charset=binary\| (No such file or directory)$"

--- a/.github/workflows/pr-check-file-encodings.yml
+++ b/.github/workflows/pr-check-file-encodings.yml
@@ -1,5 +1,7 @@
 name: check file encodings in PR
-on: pull_request
+on: 
+  pull_request:
+  merge_group:
 jobs:
   file-encoding:
     name: file encoding check


### PR DESCRIPTION
Using the merge queue has not been working recently because the file encodings check seems to run forever but never complete. I believe this will fix that, because that action was not enabled for the merge queue.