### PR TITLE
Allow checks to proceed with NAs

### DIFF
--- a/R/get_csv_specs.R
+++ b/R/get_csv_specs.R
@@ -193,7 +193,10 @@ get_csv_specs <- function(files, expected_colnames = c("Investor.Name", "Portfol
   if (all(!is.na(files_df$decimal_mark)) && all(files_df$decimal_mark == ".")) {
     cli::cli_alert_success(paste0("all files use {.strong ", cli::style_inverse("."), "} for a decimal mark"))
   } else {
-    alert_files <- files_df$filename[is.na(files_df$decimal_mark) || grepl("^[.]$", files_df$decimal_mark)]
+    alert_files <- c(
+      files_df$filename[is.na(files_df$decimal_mark)],
+      files_df$filename[grepl("^[,]$", files_df$decimal_mark)]
+    )
     report_alert_files(paste0("the following files do not use {.strong ", cli::style_inverse("."), "} for a decimal mark"), alert_files, type = "warning", info = "this can be adapted to automatically by the {.fun read_portfolio_csv} function")
   }
 
@@ -202,7 +205,10 @@ get_csv_specs <- function(files, expected_colnames = c("Investor.Name", "Portfol
   if (all(!is.na(files_df$grouping_mark)) && all(files_df$grouping_mark == ",")) {
     cli::cli_alert_success(paste0("all files use {.strong ", cli::style_inverse(","), "} for a grouping mark"))
   } else {
-    alert_files <- files_df$filename[is.na(files_df$grouping_mark) || grepl("^[,]$", files_df$grouping_mark)]
+    alert_files <- c(
+      files_df$filename[is.na(files_df$grouping_mark)],
+      files_df$filename[grepl("^[,]$", files_df$grouping_mark)]
+    )
     report_alert_files(paste0("the following files do not use {.strong ", cli::style_inverse(","), "} for a grouping mark"), alert_files, type = "warning", info = "this can be adapted to automatically by the {.fun read_portfolio_csv} function")
   }
 


### PR DESCRIPTION
previously, having an NA in either of the affected columns would fail, as the `||` operator cannot cast NA to `logical()`

Will probably get clobbered when #11 gets addressed, but works in the meantime.